### PR TITLE
irssi から接続できるようになったよ

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -91,6 +91,8 @@
     "PASSWDMISMATCH",
     "pollfds",
     "Privmsg",
+    "UMODEIS",
+    "USERSDONTMATCH",
     "YOUREOPER",
     "YOURHOST"
   ]

--- a/ft_irc/include/numericsReplies/001-099.hpp
+++ b/ft_irc/include/numericsReplies/001-099.hpp
@@ -7,17 +7,17 @@ namespace numericReplies {
 
 inline std::string RPL_WELCOME(const std::string& nick, const std::string& user,
                                const std::string& host) {
-  return "irc.42tokyo.jp 001 :Welcome to the Internet Relay Network " + nick +
-         "!" + user + "@" + host + "\r\n";
+  return ":irc.42tokyo.jp Welcome to the Internet Relay Network " + nick + "!" +
+         user + "@" + host + "\r\n";
 }
 
 inline std::string RPL_YOURHOST(const std::string& servername) {
-  return "irc.42tokyo.jp 002 :Your host is " + servername +
+  return ":irc.42tokyo.jp Your host is " + servername +
          ", running version ft_irc\r\n";
 }
 
 inline std::string RPL_CREATED(const std::string& date) {
-  return "irc.42tokyo.jp 003 :This server was created " + date + "\r\n";
+  return ":irc.42tokyo.jp This server was created " + date + "\r\n";
 }
 
 }  // namespace numericReplies

--- a/ft_irc/include/numericsReplies/001-099.hpp
+++ b/ft_irc/include/numericsReplies/001-099.hpp
@@ -7,8 +7,9 @@ namespace numericReplies {
 
 inline std::string RPL_WELCOME(const std::string& nick, const std::string& user,
                                const std::string& host) {
-  return ":irc.42tokyo.jp Welcome to the Internet Relay Network " + nick + "!" +
-         user + "@" + host + "\r\n";
+  return ":irc.42tokyo.jp 001 " + nick +
+         " Welcome to the Internet Relay Network " + nick + "!" + user + "@" +
+         host + "\r\n";
 }
 
 inline std::string RPL_YOURHOST(const std::string& servername) {

--- a/ft_irc/include/numericsReplies/001-099.hpp
+++ b/ft_irc/include/numericsReplies/001-099.hpp
@@ -1,31 +1,23 @@
 #pragma once
 
-#include <iostream>
 #include <string>
 
 namespace irc {
 namespace numericReplies {
 
-// 001
 inline std::string RPL_WELCOME(const std::string& nick, const std::string& user,
                                const std::string& host) {
-  return ":irc.42tokyo.jp 001 " + nick +
-         " :Welcome to the Internet Relay Network " + nick + "!" + user + "@" +
-         host + "\r\n";
+  return ":irc.42tokyo.jp Welcome to the Internet Relay Network " + nick + "!" +
+         user + "@" + host + "\r\n";
 }
 
-// 002
-inline std::string RPL_YOURHOST(const std::string& nick,
-                                const std::string& servername) {
-  return ":irc.42tokyo.jp 002 " + nick + " :Your host is " + servername +
+inline std::string RPL_YOURHOST(const std::string& servername) {
+  return ":irc.42tokyo.jp Your host is " + servername +
          ", running version ft_irc\r\n";
 }
 
-// 003
-inline std::string RPL_CREATED(const std::string& nick,
-                               const std::string& date) {
-  return ":irc.42tokyo.jp 003 " + nick + " :This server was created " + date +
-         "\r\n";
+inline std::string RPL_CREATED(const std::string& date) {
+  return ":irc.42tokyo.jp This server was created " + date + "\r\n";
 }
 
 }  // namespace numericReplies

--- a/ft_irc/include/numericsReplies/001-099.hpp
+++ b/ft_irc/include/numericsReplies/001-099.hpp
@@ -1,23 +1,31 @@
 #pragma once
 
+#include <iostream>
 #include <string>
 
 namespace irc {
 namespace numericReplies {
 
+// 001
 inline std::string RPL_WELCOME(const std::string& nick, const std::string& user,
                                const std::string& host) {
-  return ":irc.42tokyo.jp Welcome to the Internet Relay Network " + nick + "!" +
-         user + "@" + host + "\r\n";
+  return ":irc.42tokyo.jp 001 " + nick +
+         " :Welcome to the Internet Relay Network " + nick + "!" + user + "@" +
+         host + "\r\n";
 }
 
-inline std::string RPL_YOURHOST(const std::string& servername) {
-  return ":irc.42tokyo.jp Your host is " + servername +
+// 002
+inline std::string RPL_YOURHOST(const std::string& nick,
+                                const std::string& servername) {
+  return ":irc.42tokyo.jp 002 " + nick + " :Your host is " + servername +
          ", running version ft_irc\r\n";
 }
 
-inline std::string RPL_CREATED(const std::string& date) {
-  return ":irc.42tokyo.jp This server was created " + date + "\r\n";
+// 003
+inline std::string RPL_CREATED(const std::string& nick,
+                               const std::string& date) {
+  return ":irc.42tokyo.jp 003 " + nick + " :This server was created " + date +
+         "\r\n";
 }
 
 }  // namespace numericReplies

--- a/ft_irc/include/numericsReplies/200-299.hpp
+++ b/ft_irc/include/numericsReplies/200-299.hpp
@@ -7,7 +7,7 @@ namespace numericReplies {
 
 // 221
 inline std::string RPL_UMODEIS(const std::string& userModeString) {
-  return "irc.42tokyo.jp 221 " + userModeString + "\r\n";
+  return ":irc.42tokyo.jp " + userModeString + "\r\n";
 }
 
 }  // namespace numericReplies

--- a/ft_irc/include/numericsReplies/200-299.hpp
+++ b/ft_irc/include/numericsReplies/200-299.hpp
@@ -6,8 +6,9 @@ namespace irc {
 namespace numericReplies {
 
 // 221
-inline std::string RPL_UMODEIS(const std::string& userModeString) {
-  return ":irc.42tokyo.jp " + userModeString + "\r\n";
+inline std::string RPL_UMODEIS(const std::string& nick,
+                               const std::string& userModeString) {
+  return ":irc.42tokyo.jp 221 " + nick + " " + userModeString + "\r\n";
 }
 
 }  // namespace numericReplies

--- a/ft_irc/include/numericsReplies/200-299.hpp
+++ b/ft_irc/include/numericsReplies/200-299.hpp
@@ -6,9 +6,8 @@ namespace irc {
 namespace numericReplies {
 
 // 221
-inline std::string RPL_UMODEIS(const std::string& nick,
-                               const std::string& userModeString) {
-  return ":irc.42tokyo.jp 221 " + nick + " " + userModeString + "\r\n";
+inline std::string RPL_UMODEIS(const std::string& userModeString) {
+  return ":irc.42tokyo.jp " + userModeString + "\r\n";
 }
 
 }  // namespace numericReplies

--- a/ft_irc/include/numericsReplies/300-399.hpp
+++ b/ft_irc/include/numericsReplies/300-399.hpp
@@ -9,18 +9,18 @@ namespace numericReplies {
 inline std::string RPL_CHANNELMODEIS(const std::string& channel,
                                      const std::string& mode,
                                      const std::string& params) {
-  return "irc.42tokyo.jp 324 :" + channel + " " + mode + " " + params + "\r\n";
+  return ":irc.42tokyo.jp 324 " + channel + " " + mode + " " + params + "\r\n";
 }
 
 // 332
 inline std::string RPL_TOPIC(const std::string& channel,
                              const std::string& topic) {
-  return "irc.42tokyo.jp 332 " + channel + " :" + topic + "\r\n";
+  return ":irc.42tokyo.jp 332 " + channel + " :" + topic + "\r\n";
 }
 
 // 381
 inline std::string RPL_YOUREOPER() {
-  return "irc.42tokyo.jp 381 :You are now an IRC operator\r\n";
+  return ":irc.42tokyo.jp 381 :You are now an IRC operator\r\n";
 }
 
 }  // namespace numericReplies

--- a/ft_irc/include/numericsReplies/300-399.hpp
+++ b/ft_irc/include/numericsReplies/300-399.hpp
@@ -6,21 +6,24 @@ namespace irc {
 namespace numericReplies {
 
 // 324
-inline std::string RPL_CHANNELMODEIS(const std::string& channel,
+inline std::string RPL_CHANNELMODEIS(const std::string& nick,
+                                     const std::string& channel,
                                      const std::string& mode,
                                      const std::string& params) {
-  return ":irc.42tokyo.jp 324 " + channel + " " + mode + " " + params + "\r\n";
+  return ":irc.42tokyo.jp 324 " + nick + " " + channel + " " + mode + " " +
+         params + "\r\n";
 }
 
 // 332
-inline std::string RPL_TOPIC(const std::string& channel,
+inline std::string RPL_TOPIC(const std::string& nick,
+                             const std::string& channel,
                              const std::string& topic) {
-  return ":irc.42tokyo.jp 332 " + channel + " :" + topic + "\r\n";
+  return ":irc.42tokyo.jp 332 " + nick + " " + channel + " :" + topic + "\r\n";
 }
 
 // 381
-inline std::string RPL_YOUREOPER() {
-  return ":irc.42tokyo.jp 381 :You are now an IRC operator\r\n";
+inline std::string RPL_YOUREOPER(const std::string& nick) {
+  return ":irc.42tokyo.jp 381 " + nick + " :You are now an IRC operator\r\n";
 }
 
 }  // namespace numericReplies

--- a/ft_irc/include/numericsReplies/300-399.hpp
+++ b/ft_irc/include/numericsReplies/300-399.hpp
@@ -6,24 +6,21 @@ namespace irc {
 namespace numericReplies {
 
 // 324
-inline std::string RPL_CHANNELMODEIS(const std::string& nick,
-                                     const std::string& channel,
+inline std::string RPL_CHANNELMODEIS(const std::string& channel,
                                      const std::string& mode,
                                      const std::string& params) {
-  return ":irc.42tokyo.jp 324 " + nick + " " + channel + " " + mode + " " +
-         params + "\r\n";
+  return ":irc.42tokyo.jp 324 " + channel + " " + mode + " " + params + "\r\n";
 }
 
 // 332
-inline std::string RPL_TOPIC(const std::string& nick,
-                             const std::string& channel,
+inline std::string RPL_TOPIC(const std::string& channel,
                              const std::string& topic) {
-  return ":irc.42tokyo.jp 332 " + nick + " " + channel + " :" + topic + "\r\n";
+  return ":irc.42tokyo.jp 332 " + channel + " :" + topic + "\r\n";
 }
 
 // 381
-inline std::string RPL_YOUREOPER(const std::string& nick) {
-  return ":irc.42tokyo.jp 381 " + nick + " :You are now an IRC operator\r\n";
+inline std::string RPL_YOUREOPER() {
+  return ":irc.42tokyo.jp 381 :You are now an IRC operator\r\n";
 }
 
 }  // namespace numericReplies

--- a/ft_irc/include/numericsReplies/400-499.hpp
+++ b/ft_irc/include/numericsReplies/400-499.hpp
@@ -6,165 +6,135 @@ namespace irc {
 namespace numericReplies {
 
 // 402
-inline std::string ERR_NOSUCHSERVER(const std::string& serverName,
-                                    const std::string& nick) {
-  return ":irc.42tokyo.jp 402 " + nick + " " + serverName +
-         " :No such server\r\n";
+inline std::string ERR_NOSUCHSERVER(const std::string& serverName) {
+  return ":irc.42tokyo.jp 402 " + serverName + " :No such server\r\n";
 }
 
 // 403
-inline std::string ERR_NOSUCHCHANNEL(const std::string& channel,
-                                     const std::string& nick) {
-  return ":irc.42tokyo.jp 403 " + nick + " " + channel +
-         " :No such channel\r\n";
+inline std::string ERR_NOSUCHCHANNEL(const std::string& channel) {
+  return ":irc.42tokyo.jp 403 " + channel + " :No such channel\r\n";
 }
 
 // 405
-inline std::string ERR_TOOMANYCHANNELS(const std::string& channel,
-                                       const std::string& nick) {
-  return ":irc.42tokyo.jp 405 " + nick + " " + channel +
+inline std::string ERR_TOOMANYCHANNELS(const std::string& channel) {
+  return ":irc.42tokyo.jp 405 " + channel +
          " :You have joined too many channels\r\n";
 }
 
 // 407
 inline std::string ERR_TOOMANYTARGETS(const std::string& target,
                                       const std::string& errorCode,
-                                      const std::string& abortMessage,
-                                      const std::string& nick) {
-  return ":irc.42tokyo.jp 407 " + nick + " " + target + " :" + errorCode +
-         " recipients. " + abortMessage + "\r\n";
+                                      const std::string& abortMessage) {
+  return ":irc.42tokyo.jp 407 " + target + " :" + errorCode + " recipients. " +
+         abortMessage + "\r\n";
 }
 
 // 421
-inline std::string ERR_UNKNOWNCOMMAND(const std::string& command,
-                                      const std::string& nick) {
-  return ":irc.42tokyo.jp 421 " + nick + " " + command +
-         " :Unknown command\r\n";
+inline std::string ERR_UNKNOWNCOMMAND(const std::string& command) {
+  return ":irc.42tokyo.jp 421 " + command + " :Unknown command\r\n";
 }
 
 // 431
-inline std::string ERR_NONICKNAMEGIVEN(const std::string& nick) {
-  return ":irc.42tokyo.jp 431 " + nick + " :No nickname given\r\n";
+inline std::string ERR_NONICKNAMEGIVEN() {
+  return ":irc.42tokyo.jp 431 :No nickname given\r\n";
 }
 
 // 432
-inline std::string ERR_ERRONEUSNICKNAME(const std::string& nickname,
-                                        const std::string& nick) {
-  return ":irc.42tokyo.jp 432 " + nick + " " + nickname +
-         " :Erroneous nickname\r\n";
+inline std::string ERR_ERRONEUSNICKNAME(const std::string& nickname) {
+  return ":irc.42tokyo.jp 432 " + nickname + " :Erroneous nickname\r\n";
 }
 
 // 433
-inline std::string ERR_NICKNAMEINUSE(const std::string& nickname,
-                                     const std::string& nick) {
-  return ":irc.42tokyo.jp 433 " + nick + " " + nickname +
-         " :Nickname is already in use\r\n";
+inline std::string ERR_NICKNAMEINUSE(const std::string& nickname) {
+  return ":irc.42tokyo.jp 433 " + nickname + " :Nickname is already in use\r\n";
 }
 
 // 436
 inline std::string ERR_NICKCOLLISION(const std::string& nickname,
                                      const std::string& user,
-                                     const std::string& host,
-                                     const std::string& nick) {
-  return ":irc.42tokyo.jp 436 " + nick + " " + nickname +
-         " :Nickname collision KILL from " + user + "@" + host + "\r\n";
+                                     const std::string& host) {
+  return ":irc.42tokyo.jp 436 " + nickname + " :Nickname collision KILL from " +
+         user + "@" + host + "\r\n";
 }
 
 // 437
 inline std::string ERR_UNAVAILRESOURCE(const std::string& nickname,
-                                       const std::string& channel,
-                                       const std::string& nick) {
-  return ":irc.42tokyo.jp 437 " + nick + " " + nickname + "/" + channel +
+                                       const std::string& channel) {
+  return ":irc.42tokyo.jp 437 " + nickname + "/" + channel +
          " :Nick/channel is temporarily unavailable\r\n";
 }
 
 // 451
-inline std::string ERR_NOTREGISTERED(const std::string& nick) {
-  return ":irc.42tokyo.jp 451 " + nick + " :You have not registered\r\n";
+inline std::string ERR_NOTREGISTERED() {
+  return ":irc.42tokyo.jp 451 :You have not registered\r\n";
 }
 
 // 461
-inline std::string ERR_NEEDMOREPARAMS(const std::string& command,
-                                      const std::string& nick) {
-  return ":irc.42tokyo.jp 461 " + nick + " " + command +
-         " :Not enough parameters\r\n";
+inline std::string ERR_NEEDMOREPARAMS(const std::string& command) {
+  return ":irc.42tokyo.jp 461 " + command + " :Not enough parameters\r\n";
 }
 
 // 462
-inline std::string ERR_ALREADYREGISTRED(const std::string& nick) {
-  return ":irc.42tokyo.jp 462 " + nick +
-         " :Unauthorized command (already registered)\r\n";
+inline std::string ERR_ALREADYREGISTRED() {
+  return ":irc.42tokyo.jp 462 :Unauthorized command (already registered)\r\n";
 }
 
 // 464
-inline std::string ERR_PASSWDMISMATCH(const std::string& nick) {
-  return ":server 464 " + nick + " :Password incorrect\r\n";
+inline std::string ERR_PASSWDMISMATCH() {
+  return ":server 464 :Password incorrect\r\n";
 }
 
 // 471
-inline std::string ERR_CHANNELISFULL(const std::string& channel,
-                                     const std::string& nick) {
-  return ":irc.42tokyo.jp 471 " + nick + " " + channel +
-         " :Cannot join channel (+l)\r\n";
+inline std::string ERR_CHANNELISFULL(const std::string& channel) {
+  return ":irc.42tokyo.jp 471 " + channel + " :Cannot join channel (+l)\r\n";
 }
 
 // 472
-inline std::string ERR_UNKNOWNMODE(char mode, const std::string& channel,
-                                   const std::string& nick) {
-  return ":irc.42tokyo.jp 472 " + nick + " " + std::string(1, mode) +
+inline std::string ERR_UNKNOWNMODE(char mode, const std::string& channel) {
+  return ":irc.42tokyo.jp 472 " + std::string(1, mode) +
          " :is unknown mode char to me for " + channel + "\r\n";
 }
 
 // 473
-inline std::string ERR_INVITEONLYCHAN(const std::string& channel,
-                                      const std::string& nick) {
-  return ":irc.42tokyo.jp 473 " + nick + " " + channel +
-         " :Cannot join channel (+i)\r\n";
+inline std::string ERR_INVITEONLYCHAN(const std::string& channel) {
+  return ":irc.42tokyo.jp 473 " + channel + " :Cannot join channel (+i)\r\n";
 }
 
 // 474
-inline std::string ERR_BANNEDFROMCHAN(const std::string& channel,
-                                      const std::string& nick) {
-  return ":irc.42tokyo.jp 474 " + nick + " " + channel +
-         " :Cannot join channel (+b)\r\n";
+inline std::string ERR_BANNEDFROMCHAN(const std::string& channel) {
+  return ":irc.42tokyo.jp 474 " + channel + " :Cannot join channel (+b)\r\n";
 }
 
 // 475
-inline std::string ERR_BADCHANNELKEY(const std::string& channel,
-                                     const std::string& nick) {
-  return ":irc.42tokyo.jp 475 " + nick + " " + channel +
-         " :Cannot join channel (+k)\r\n";
+inline std::string ERR_BADCHANNELKEY(const std::string& channel) {
+  return ":irc.42tokyo.jp 475 " + channel + " :Cannot join channel (+k)\r\n";
 }
 
 // 476
-inline std::string ERR_BADCHANMASK(const std::string& channel,
-                                   const std::string& nick) {
-  return ":irc.42tokyo.jp 476 " + nick + " " + channel +
-         " :Bad Channel Mask\r\n";
+inline std::string ERR_BADCHANMASK(const std::string& channel) {
+  return ":irc.42tokyo.jp 476 " + channel + " :Bad Channel Mask\r\n";
 }
 
 // 481
-inline std::string ERR_NOPRIVILEGES(const std::string& nick) {
-  return ":irc.42tokyo.jp 481 " + nick +
-         " :Permission Denied - You're not an IRC "
+inline std::string ERR_NOPRIVILEGES() {
+  return ":irc.42tokyo.jp 481 :Permission Denied - You're not an IRC "
          "operator\r\n";
 }
 
 // 482
-inline std::string ERR_CHANOPRIVSNEEDED(const std::string& channel,
-                                        const std::string& nick) {
-  return ":irc.42tokyo.jp 482 " + nick + " :" + channel +
+inline std::string ERR_CHANOPRIVSNEEDED(const std::string& channel) {
+  return ":irc.42tokyo.jp 482 :" + channel +
          " :You're not channel operator\r\n";
 }
 
 // 484
-inline std::string ERR_RESTRICTED(const std::string& nick) {
-  return ":irc.42tokyo.jp 484 " + nick + " :Your connection is restricted!\r\n";
+inline std::string ERR_RESTRICTED() {
+  return ":irc.42tokyo.jp 484 :Your connection is restricted!\r\n";
 }
 
 // 491
-inline std::string ERR_NOOPERHOST(const std::string& nick) {
-  return ":irc.42tokyo.jp 491 " + nick + " :No O-lines for your host\r\n";
+inline std::string ERR_NOOPERHOST() {
+  return ":irc.42tokyo.jp 491 :No O-lines for your host\r\n";
 }
 
 }  // namespace numericReplies

--- a/ft_irc/include/numericsReplies/400-499.hpp
+++ b/ft_irc/include/numericsReplies/400-499.hpp
@@ -30,8 +30,10 @@ inline std::string ERR_TOOMANYTARGETS(const std::string& target,
 }
 
 // 421
-inline std::string ERR_UNKNOWNCOMMAND(const std::string& command) {
-  return ":irc.42tokyo.jp 421 " + command + " :Unknown command\r\n";
+inline std::string ERR_UNKNOWNCOMMAND(const std::string nick,
+                                      const std::string& command) {
+  return ":irc.42tokyo.jp 421 " + nick + " " + command +
+         " :Unknown command\r\n";
 }
 
 // 431

--- a/ft_irc/include/numericsReplies/400-499.hpp
+++ b/ft_irc/include/numericsReplies/400-499.hpp
@@ -7,17 +7,17 @@ namespace numericReplies {
 
 // 402
 inline std::string ERR_NOSUCHSERVER(const std::string& serverName) {
-  return "irc.42tokyo.jp 402 " + serverName + " :No such server\r\n";
+  return ":irc.42tokyo.jp 402 " + serverName + " :No such server\r\n";
 }
 
 // 403
 inline std::string ERR_NOSUCHCHANNEL(const std::string& channel) {
-  return "irc.42tokyo.jp 403 " + channel + " :No such channel\r\n";
+  return ":irc.42tokyo.jp 403 " + channel + " :No such channel\r\n";
 }
 
 // 405
 inline std::string ERR_TOOMANYCHANNELS(const std::string& channel) {
-  return "irc.42tokyo.jp 405 " + channel +
+  return ":irc.42tokyo.jp 405 " + channel +
          " :You have joined too many channels\r\n";
 }
 
@@ -25,115 +25,116 @@ inline std::string ERR_TOOMANYCHANNELS(const std::string& channel) {
 inline std::string ERR_TOOMANYTARGETS(const std::string& target,
                                       const std::string& errorCode,
                                       const std::string& abortMessage) {
-  return "irc.42tokyo.jp 407 " + target + " :" + errorCode + " recipients. " +
+  return ":irc.42tokyo.jp 407 " + target + " :" + errorCode + " recipients. " +
          abortMessage + "\r\n";
 }
 
 // 421
 inline std::string ERR_UNKNOWNCOMMAND(const std::string& command) {
-  return "irc.42tokyo.jp 421 " + command + " :Unknown command\r\n";
+  return ":irc.42tokyo.jp 421 " + command + " :Unknown command\r\n";
 }
 
 // 431
 inline std::string ERR_NONICKNAMEGIVEN() {
-  return "irc.42tokyo.jp 431 :No nickname given\r\n";
+  return ":irc.42tokyo.jp 431 :No nickname given\r\n";
 }
 
 // 432
 inline std::string ERR_ERRONEUSNICKNAME(const std::string& nickname) {
-  return "irc.42tokyo.jp 432 " + nickname + " :Erroneous nickname\r\n";
+  return ":irc.42tokyo.jp 432 " + nickname + " :Erroneous nickname\r\n";
 }
 
 // 433
 inline std::string ERR_NICKNAMEINUSE(const std::string& nickname) {
-  return "irc.42tokyo.jp 433 " + nickname + " :Nickname is already in use\r\n";
+  return ":irc.42tokyo.jp 433 " + nickname + " :Nickname is already in use\r\n";
 }
 
 // 436
 inline std::string ERR_NICKCOLLISION(const std::string& nickname,
                                      const std::string& user,
                                      const std::string& host) {
-  return "irc.42tokyo.jp 436 " + nickname + " :Nickname collision KILL from " +
+  return ":irc.42tokyo.jp 436 " + nickname + " :Nickname collision KILL from " +
          user + "@" + host + "\r\n";
 }
 
 // 437
 inline std::string ERR_UNAVAILRESOURCE(const std::string& nickname,
                                        const std::string& channel) {
-  return "irc.42tokyo.jp 437 " + nickname + "/" + channel +
+  return ":irc.42tokyo.jp 437 " + nickname + "/" + channel +
          " :Nick/channel is temporarily unavailable\r\n";
 }
 
 // 451
 inline std::string ERR_NOTREGISTERED() {
-  return "irc.42tokyo.jp 451 :You have not registered\r\n";
+  return ":irc.42tokyo.jp 451 :You have not registered\r\n";
 }
 
 // 461
 inline std::string ERR_NEEDMOREPARAMS(const std::string& command) {
-  return "irc.42tokyo.jp 461 " + command + " :Not enough parameters\r\n";
+  return ":irc.42tokyo.jp 461 " + command + " :Not enough parameters\r\n";
 }
 
 // 462
 inline std::string ERR_ALREADYREGISTRED() {
-  return "irc.42tokyo.jp 462 :Unauthorized command (already registered)\r\n";
+  return ":irc.42tokyo.jp 462 :Unauthorized command (already registered)\r\n";
 }
 
 // 464
 inline std::string ERR_PASSWDMISMATCH() {
-  return "irc.42tokyo.jp 464 :Password incorrect\r\n";
+  return ":server 464 :Password incorrect\r\n";
 }
 
 // 471
 inline std::string ERR_CHANNELISFULL(const std::string& channel) {
-  return "irc.42tokyo.jp 471 " + channel + " :Cannot join channel (+l)\r\n";
+  return ":irc.42tokyo.jp 471 " + channel + " :Cannot join channel (+l)\r\n";
 }
 
 // 472
 inline std::string ERR_UNKNOWNMODE(char mode, const std::string& channel) {
-  return "irc.42tokyo.jp 472 :" + std::string(1, mode) +
+  return ":irc.42tokyo.jp 472 " + std::string(1, mode) +
          " :is unknown mode char to me for " + channel + "\r\n";
 }
 
 // 473
 inline std::string ERR_INVITEONLYCHAN(const std::string& channel) {
-  return "irc.42tokyo.jp 473 " + channel + " :Cannot join channel (+i)\r\n";
+  return ":irc.42tokyo.jp 473 " + channel + " :Cannot join channel (+i)\r\n";
 }
 
 // 474
 inline std::string ERR_BANNEDFROMCHAN(const std::string& channel) {
-  return "irc.42tokyo.jp 474 " + channel + " :Cannot join channel (+b)\r\n";
+  return ":irc.42tokyo.jp 474 " + channel + " :Cannot join channel (+b)\r\n";
 }
 
 // 475
 inline std::string ERR_BADCHANNELKEY(const std::string& channel) {
-  return "irc.42tokyo.jp 475 " + channel + " :Cannot join channel (+k)\r\n";
+  return ":irc.42tokyo.jp 475 " + channel + " :Cannot join channel (+k)\r\n";
 }
 
 // 476
 inline std::string ERR_BADCHANMASK(const std::string& channel) {
-  return "irc.42tokyo.jp 476 " + channel + " :Bad Channel Mask\r\n";
+  return ":irc.42tokyo.jp 476 " + channel + " :Bad Channel Mask\r\n";
 }
 
 // 481
 inline std::string ERR_NOPRIVILEGES() {
-  return "irc.42tokyo.jp 481 :Permission Denied - You're not an IRC "
+  return ":irc.42tokyo.jp 481 :Permission Denied - You're not an IRC "
          "operator\r\n";
 }
 
 // 482
 inline std::string ERR_CHANOPRIVSNEEDED(const std::string& channel) {
-  return "irc.42tokyo.jp 482 :" + channel + " :You're not channel operator\r\n";
+  return ":irc.42tokyo.jp 482 :" + channel +
+         " :You're not channel operator\r\n";
 }
 
 // 484
 inline std::string ERR_RESTRICTED() {
-  return "irc.42tokyo.jp 484 :Your connection is restricted!\r\n";
+  return ":irc.42tokyo.jp 484 :Your connection is restricted!\r\n";
 }
 
 // 491
 inline std::string ERR_NOOPERHOST() {
-  return "irc.42tokyo.jp 491 :No O-lines for your host\r\n";
+  return ":irc.42tokyo.jp 491 :No O-lines for your host\r\n";
 }
 
 }  // namespace numericReplies

--- a/ft_irc/include/numericsReplies/400-499.hpp
+++ b/ft_irc/include/numericsReplies/400-499.hpp
@@ -6,135 +6,165 @@ namespace irc {
 namespace numericReplies {
 
 // 402
-inline std::string ERR_NOSUCHSERVER(const std::string& serverName) {
-  return ":irc.42tokyo.jp 402 " + serverName + " :No such server\r\n";
+inline std::string ERR_NOSUCHSERVER(const std::string& serverName,
+                                    const std::string& nick) {
+  return ":irc.42tokyo.jp 402 " + nick + " " + serverName +
+         " :No such server\r\n";
 }
 
 // 403
-inline std::string ERR_NOSUCHCHANNEL(const std::string& channel) {
-  return ":irc.42tokyo.jp 403 " + channel + " :No such channel\r\n";
+inline std::string ERR_NOSUCHCHANNEL(const std::string& channel,
+                                     const std::string& nick) {
+  return ":irc.42tokyo.jp 403 " + nick + " " + channel +
+         " :No such channel\r\n";
 }
 
 // 405
-inline std::string ERR_TOOMANYCHANNELS(const std::string& channel) {
-  return ":irc.42tokyo.jp 405 " + channel +
+inline std::string ERR_TOOMANYCHANNELS(const std::string& channel,
+                                       const std::string& nick) {
+  return ":irc.42tokyo.jp 405 " + nick + " " + channel +
          " :You have joined too many channels\r\n";
 }
 
 // 407
 inline std::string ERR_TOOMANYTARGETS(const std::string& target,
                                       const std::string& errorCode,
-                                      const std::string& abortMessage) {
-  return ":irc.42tokyo.jp 407 " + target + " :" + errorCode + " recipients. " +
-         abortMessage + "\r\n";
+                                      const std::string& abortMessage,
+                                      const std::string& nick) {
+  return ":irc.42tokyo.jp 407 " + nick + " " + target + " :" + errorCode +
+         " recipients. " + abortMessage + "\r\n";
 }
 
 // 421
-inline std::string ERR_UNKNOWNCOMMAND(const std::string& command) {
-  return ":irc.42tokyo.jp 421 " + command + " :Unknown command\r\n";
+inline std::string ERR_UNKNOWNCOMMAND(const std::string& command,
+                                      const std::string& nick) {
+  return ":irc.42tokyo.jp 421 " + nick + " " + command +
+         " :Unknown command\r\n";
 }
 
 // 431
-inline std::string ERR_NONICKNAMEGIVEN() {
-  return ":irc.42tokyo.jp 431 :No nickname given\r\n";
+inline std::string ERR_NONICKNAMEGIVEN(const std::string& nick) {
+  return ":irc.42tokyo.jp 431 " + nick + " :No nickname given\r\n";
 }
 
 // 432
-inline std::string ERR_ERRONEUSNICKNAME(const std::string& nickname) {
-  return ":irc.42tokyo.jp 432 " + nickname + " :Erroneous nickname\r\n";
+inline std::string ERR_ERRONEUSNICKNAME(const std::string& nickname,
+                                        const std::string& nick) {
+  return ":irc.42tokyo.jp 432 " + nick + " " + nickname +
+         " :Erroneous nickname\r\n";
 }
 
 // 433
-inline std::string ERR_NICKNAMEINUSE(const std::string& nickname) {
-  return ":irc.42tokyo.jp 433 " + nickname + " :Nickname is already in use\r\n";
+inline std::string ERR_NICKNAMEINUSE(const std::string& nickname,
+                                     const std::string& nick) {
+  return ":irc.42tokyo.jp 433 " + nick + " " + nickname +
+         " :Nickname is already in use\r\n";
 }
 
 // 436
 inline std::string ERR_NICKCOLLISION(const std::string& nickname,
                                      const std::string& user,
-                                     const std::string& host) {
-  return ":irc.42tokyo.jp 436 " + nickname + " :Nickname collision KILL from " +
-         user + "@" + host + "\r\n";
+                                     const std::string& host,
+                                     const std::string& nick) {
+  return ":irc.42tokyo.jp 436 " + nick + " " + nickname +
+         " :Nickname collision KILL from " + user + "@" + host + "\r\n";
 }
 
 // 437
 inline std::string ERR_UNAVAILRESOURCE(const std::string& nickname,
-                                       const std::string& channel) {
-  return ":irc.42tokyo.jp 437 " + nickname + "/" + channel +
+                                       const std::string& channel,
+                                       const std::string& nick) {
+  return ":irc.42tokyo.jp 437 " + nick + " " + nickname + "/" + channel +
          " :Nick/channel is temporarily unavailable\r\n";
 }
 
 // 451
-inline std::string ERR_NOTREGISTERED() {
-  return ":irc.42tokyo.jp 451 :You have not registered\r\n";
+inline std::string ERR_NOTREGISTERED(const std::string& nick) {
+  return ":irc.42tokyo.jp 451 " + nick + " :You have not registered\r\n";
 }
 
 // 461
-inline std::string ERR_NEEDMOREPARAMS(const std::string& command) {
-  return ":irc.42tokyo.jp 461 " + command + " :Not enough parameters\r\n";
+inline std::string ERR_NEEDMOREPARAMS(const std::string& command,
+                                      const std::string& nick) {
+  return ":irc.42tokyo.jp 461 " + nick + " " + command +
+         " :Not enough parameters\r\n";
 }
 
 // 462
-inline std::string ERR_ALREADYREGISTRED() {
-  return ":irc.42tokyo.jp 462 :Unauthorized command (already registered)\r\n";
+inline std::string ERR_ALREADYREGISTRED(const std::string& nick) {
+  return ":irc.42tokyo.jp 462 " + nick +
+         " :Unauthorized command (already registered)\r\n";
 }
 
 // 464
-inline std::string ERR_PASSWDMISMATCH() {
-  return ":server 464 :Password incorrect\r\n";
+inline std::string ERR_PASSWDMISMATCH(const std::string& nick) {
+  return ":server 464 " + nick + " :Password incorrect\r\n";
 }
 
 // 471
-inline std::string ERR_CHANNELISFULL(const std::string& channel) {
-  return ":irc.42tokyo.jp 471 " + channel + " :Cannot join channel (+l)\r\n";
+inline std::string ERR_CHANNELISFULL(const std::string& channel,
+                                     const std::string& nick) {
+  return ":irc.42tokyo.jp 471 " + nick + " " + channel +
+         " :Cannot join channel (+l)\r\n";
 }
 
 // 472
-inline std::string ERR_UNKNOWNMODE(char mode, const std::string& channel) {
-  return ":irc.42tokyo.jp 472 " + std::string(1, mode) +
+inline std::string ERR_UNKNOWNMODE(char mode, const std::string& channel,
+                                   const std::string& nick) {
+  return ":irc.42tokyo.jp 472 " + nick + " " + std::string(1, mode) +
          " :is unknown mode char to me for " + channel + "\r\n";
 }
 
 // 473
-inline std::string ERR_INVITEONLYCHAN(const std::string& channel) {
-  return ":irc.42tokyo.jp 473 " + channel + " :Cannot join channel (+i)\r\n";
+inline std::string ERR_INVITEONLYCHAN(const std::string& channel,
+                                      const std::string& nick) {
+  return ":irc.42tokyo.jp 473 " + nick + " " + channel +
+         " :Cannot join channel (+i)\r\n";
 }
 
 // 474
-inline std::string ERR_BANNEDFROMCHAN(const std::string& channel) {
-  return ":irc.42tokyo.jp 474 " + channel + " :Cannot join channel (+b)\r\n";
+inline std::string ERR_BANNEDFROMCHAN(const std::string& channel,
+                                      const std::string& nick) {
+  return ":irc.42tokyo.jp 474 " + nick + " " + channel +
+         " :Cannot join channel (+b)\r\n";
 }
 
 // 475
-inline std::string ERR_BADCHANNELKEY(const std::string& channel) {
-  return ":irc.42tokyo.jp 475 " + channel + " :Cannot join channel (+k)\r\n";
+inline std::string ERR_BADCHANNELKEY(const std::string& channel,
+                                     const std::string& nick) {
+  return ":irc.42tokyo.jp 475 " + nick + " " + channel +
+         " :Cannot join channel (+k)\r\n";
 }
 
 // 476
-inline std::string ERR_BADCHANMASK(const std::string& channel) {
-  return ":irc.42tokyo.jp 476 " + channel + " :Bad Channel Mask\r\n";
+inline std::string ERR_BADCHANMASK(const std::string& channel,
+                                   const std::string& nick) {
+  return ":irc.42tokyo.jp 476 " + nick + " " + channel +
+         " :Bad Channel Mask\r\n";
 }
 
 // 481
-inline std::string ERR_NOPRIVILEGES() {
-  return ":irc.42tokyo.jp 481 :Permission Denied - You're not an IRC "
+inline std::string ERR_NOPRIVILEGES(const std::string& nick) {
+  return ":irc.42tokyo.jp 481 " + nick +
+         " :Permission Denied - You're not an IRC "
          "operator\r\n";
 }
 
 // 482
-inline std::string ERR_CHANOPRIVSNEEDED(const std::string& channel) {
-  return ":irc.42tokyo.jp 482 :" + channel +
+inline std::string ERR_CHANOPRIVSNEEDED(const std::string& channel,
+                                        const std::string& nick) {
+  return ":irc.42tokyo.jp 482 " + nick + " :" + channel +
          " :You're not channel operator\r\n";
 }
 
 // 484
-inline std::string ERR_RESTRICTED() {
-  return ":irc.42tokyo.jp 484 :Your connection is restricted!\r\n";
+inline std::string ERR_RESTRICTED(const std::string& nick) {
+  return ":irc.42tokyo.jp 484 " + nick + " :Your connection is restricted!\r\n";
 }
 
 // 491
-inline std::string ERR_NOOPERHOST() {
-  return ":irc.42tokyo.jp 491 :No O-lines for your host\r\n";
+inline std::string ERR_NOOPERHOST(const std::string& nick) {
+  return ":irc.42tokyo.jp 491 " + nick + " :No O-lines for your host\r\n";
 }
 
 }  // namespace numericReplies

--- a/ft_irc/include/numericsReplies/500-599.hpp
+++ b/ft_irc/include/numericsReplies/500-599.hpp
@@ -7,12 +7,12 @@ namespace numericReplies {
 
 // 501
 inline std::string ERR_UMODEUNKNOWNFLAG() {
-  return "irc.42tokyo.jp 501 :Unknown MODE flag\r\n";
+  return ":irc.42tokyo.jp 501 :Unknown MODE flag\r\n";
 }
 
 // 502
 inline std::string ERR_USERSDONTMATCH() {
-  return "irc.42tokyo.jp 502 :Cannot change mode for other users\r\n";
+  return ":irc.42tokyo.jp 502 :Cannot change mode for other users\r\n";
 }
 
 }  // namespace numericReplies

--- a/ft_irc/include/numericsReplies/500-599.hpp
+++ b/ft_irc/include/numericsReplies/500-599.hpp
@@ -6,13 +6,14 @@ namespace irc {
 namespace numericReplies {
 
 // 501
-inline std::string ERR_UMODEUNKNOWNFLAG() {
-  return ":irc.42tokyo.jp 501 :Unknown MODE flag\r\n";
+inline std::string ERR_UMODEUNKNOWNFLAG(const std::string& nick) {
+  return ":irc.42tokyo.jp 501 " + nick + " :Unknown MODE flag\r\n";
 }
 
 // 502
-inline std::string ERR_USERSDONTMATCH() {
-  return ":irc.42tokyo.jp 502 :Cannot change mode for other users\r\n";
+inline std::string ERR_USERSDONTMATCH(const std::string& nick) {
+  return ":irc.42tokyo.jp 502 " + nick +
+         " :Cannot change mode for other users\r\n";
 }
 
 }  // namespace numericReplies

--- a/ft_irc/include/numericsReplies/500-599.hpp
+++ b/ft_irc/include/numericsReplies/500-599.hpp
@@ -6,14 +6,13 @@ namespace irc {
 namespace numericReplies {
 
 // 501
-inline std::string ERR_UMODEUNKNOWNFLAG(const std::string& nick) {
-  return ":irc.42tokyo.jp 501 " + nick + " :Unknown MODE flag\r\n";
+inline std::string ERR_UMODEUNKNOWNFLAG() {
+  return ":irc.42tokyo.jp 501 :Unknown MODE flag\r\n";
 }
 
 // 502
-inline std::string ERR_USERSDONTMATCH(const std::string& nick) {
-  return ":irc.42tokyo.jp 502 " + nick +
-         " :Cannot change mode for other users\r\n";
+inline std::string ERR_USERSDONTMATCH() {
+  return ":irc.42tokyo.jp 502 :Cannot change mode for other users\r\n";
 }
 
 }  // namespace numericReplies

--- a/ft_irc/src/Server.cpp
+++ b/ft_irc/src/Server.cpp
@@ -151,26 +151,18 @@ void Server::_handleClientActivity(size_t index) {
   _processClientBuffer(client);  // クライアントのバッファを処理
 }
 
-// 制御文字の除去（現在は \r のみ）
-static std::string sanitizeLine(const std::string& input) {
-  std::string line = input;
-  if (!line.empty() && line[line.size() - 1] == '\r')
-    line.erase(line.size() - 1);
-  return line;
-}
-
 void Server::_processClientBuffer(Client* client) {
+  std::string& buf = client->getReadBuffer();
   size_t pos;
-  while ((pos = client->getReadBuffer().find("\n")) != std::string::npos) {
-    std::string rawLine = client->getReadBuffer().substr(0, pos);
-    client->getReadBuffer().erase(0, pos + 1);
 
-    std::string line = sanitizeLine(rawLine);
+  while ((pos = buf.find("\r\n")) != std::string::npos) {
+    std::string line = buf.substr(0, pos);
+    buf.erase(0, pos + 2);
+
     if (line.empty())
       continue;
 
     commandS cmd = _parser.parseCommand(line);
-
     if (cmd.name.empty())
       continue;  // 無効なコマンドはスキップ
 

--- a/ft_irc/src/Server.cpp
+++ b/ft_irc/src/Server.cpp
@@ -190,10 +190,8 @@ void Server::_commandDispatch(const commandS& cmd, Client& client) {
     return;
   }
 
-  // std::string msg = irc::numericReplies::ERR_UNKNOWNCOMMAND(cmd.name);
-
-  std::string msg = ":server 421 " + client.getNickname() + " " + cmd.name +
-                    " :Unknown command\r\n";
+  std::string msg =
+      irc::numericReplies::ERR_UNKNOWNCOMMAND(client.getNickname(), cmd.name);
   send(client.getFd(), msg.c_str(), msg.size(), 0);
 }
 

--- a/ft_irc/src/Server.cpp
+++ b/ft_irc/src/Server.cpp
@@ -152,7 +152,7 @@ void Server::_handleClientActivity(size_t index) {
 }
 
 // 制御文字の除去（現在は \r のみ）
-std::string sanitizeLine(const std::string& input) {
+static std::string sanitizeLine(const std::string& input) {
   std::string line = input;
   if (!line.empty() && line[line.size() - 1] == '\r')
     line.erase(line.size() - 1);


### PR DESCRIPTION
# 概要
NumericsReplyの変更と '\r' のトリミング

## 変更点

- NumericsReplyをIRC仕様に準拠した形に修正しました。特にメッセージ部の `:` の位置及び、数字の後に `nickname` がないと、irssi などのクライアントで正しく認識されないため、重要な修正です。
- クライアントからの入力処理で、行末の \r（キャリッジリターン）を安全にトリミングするように変更しました。( `\r\n` は必須にしました）

## 影響範囲

- IRCクライアント（特に irssi）との接続処理および初期通信（PASS, NICK, USER, CAP など）
- NumericsReply の出力形式（サーバーからクライアントへのレスポンス）
- クライアントの受信バッファ処理およびパーサの安定性

## テスト

- irssi からローカルサーバーに接続 → PASS/NICK/USER を順に送信して成功することを確認
- クライアントが \r\n 区切りで送信してきた場合に \r を正しくトリミングし、コマンドが正常に処理されることを確認
- NumericsReply の形式が RFC に準拠しており、クライアント側で異常表示や警告が出ないことを確認