### PR TITLE
NumericsReplies のターゲット（nick）を追加

### DIFF
--- a/ft_irc/include/numericsReplies/001-099.hpp
+++ b/ft_irc/include/numericsReplies/001-099.hpp
@@ -5,20 +5,36 @@
 namespace irc {
 namespace numericReplies {
 
+// 001
 inline std::string RPL_WELCOME(const std::string& nick, const std::string& user,
                                const std::string& host) {
   return ":irc.42tokyo.jp 001 " + nick +
-         " Welcome to the Internet Relay Network " + nick + "!" + user + "@" +
+         " :Welcome to the Internet Relay Network " + nick + "!" + user + "@" +
          host + "\r\n";
 }
 
-inline std::string RPL_YOURHOST(const std::string& servername) {
-  return ":irc.42tokyo.jp Your host is " + servername +
+// 002
+inline std::string RPL_YOURHOST(const std::string& nick,
+                                const std::string& servername) {
+  return ":irc.42tokyo.jp 002 " + nick + " :Your host is " + servername +
          ", running version ft_irc\r\n";
 }
 
-inline std::string RPL_CREATED(const std::string& date) {
-  return ":irc.42tokyo.jp This server was created " + date + "\r\n";
+// 003
+inline std::string RPL_CREATED(const std::string& nick,
+                               const std::string& date) {
+  return ":irc.42tokyo.jp 003 " + nick + " :This server was created " + date +
+         "\r\n";
+}
+
+// 004
+inline std::string RPL_MYINFO(const std::string& nick,
+                              const std::string& servername,
+                              const std::string& version,
+                              const std::string& userModes,
+                              const std::string& channelModes) {
+  return ":irc.42tokyo.jp 004 " + nick + " " + servername + " " + version +
+         " " + userModes + " " + channelModes + "\r\n";
 }
 
 }  // namespace numericReplies

--- a/ft_irc/include/numericsReplies/300-399.hpp
+++ b/ft_irc/include/numericsReplies/300-399.hpp
@@ -6,21 +6,24 @@ namespace irc {
 namespace numericReplies {
 
 // 324
-inline std::string RPL_CHANNELMODEIS(const std::string& channel,
+inline std::string RPL_CHANNELMODEIS(const std::string& nick,
+                                     const std::string& channel,
                                      const std::string& mode,
                                      const std::string& params) {
-  return ":irc.42tokyo.jp 324 " + channel + " " + mode + " " + params + "\r\n";
+  return ":irc.42tokyo.jp 324 " + nick + " :" + channel + " " + mode + " " +
+         params + "\r\n";
 }
 
 // 332
-inline std::string RPL_TOPIC(const std::string& channel,
+inline std::string RPL_TOPIC(const std::string& nick,
+                             const std::string& channel,
                              const std::string& topic) {
-  return ":irc.42tokyo.jp 332 " + channel + " :" + topic + "\r\n";
+  return ":irc.42tokyo.jp 332 " + nick + " " + channel + " :" + topic + "\r\n";
 }
 
 // 381
-inline std::string RPL_YOUREOPER() {
-  return ":irc.42tokyo.jp 381 :You are now an IRC operator\r\n";
+inline std::string RPL_YOUREOPER(const std::string& nick) {
+  return ":irc.42tokyo.jp 381 " + nick + " :You are now an IRC operator\r\n";
 }
 
 }  // namespace numericReplies

--- a/ft_irc/include/numericsReplies/400-499.hpp
+++ b/ft_irc/include/numericsReplies/400-499.hpp
@@ -6,137 +6,186 @@ namespace irc {
 namespace numericReplies {
 
 // 402
-inline std::string ERR_NOSUCHSERVER(const std::string& serverName) {
-  return ":irc.42tokyo.jp 402 " + serverName + " :No such server\r\n";
+inline std::string ERR_NOSUCHSERVER(const std::string& nick,
+                                    const std::string& serverName) {
+  return ":irc.42tokyo.jp 402 " + nick + " " + serverName +
+         " :No such server\r\n";
 }
 
 // 403
-inline std::string ERR_NOSUCHCHANNEL(const std::string& channel) {
-  return ":irc.42tokyo.jp 403 " + channel + " :No such channel\r\n";
+inline std::string ERR_NOSUCHCHANNEL(const std::string& nick,
+                                     const std::string& channel) {
+  return ":irc.42tokyo.jp 403 " + nick + " " + channel +
+         " :No such channel\r\n";
+}
+
+// 404
+inline std::string ERR_CANNOTSENDTOCHAN(const std::string& nick,
+                                        const std::string& channel) {
+  return ":irc.42tokyo.jp 404 " + nick + " " + channel +
+         " :Cannot send to channel\r\n";
 }
 
 // 405
-inline std::string ERR_TOOMANYCHANNELS(const std::string& channel) {
-  return ":irc.42tokyo.jp 405 " + channel +
+inline std::string ERR_TOOMANYCHANNELS(const std::string& nick,
+                                       const std::string& channel) {
+  return ":irc.42tokyo.jp 405 " + nick + " " + channel +
          " :You have joined too many channels\r\n";
 }
 
 // 407
-inline std::string ERR_TOOMANYTARGETS(const std::string& target,
+inline std::string ERR_TOOMANYTARGETS(const std::string& nick,
+                                      const std::string& target,
                                       const std::string& errorCode,
                                       const std::string& abortMessage) {
-  return ":irc.42tokyo.jp 407 " + target + " :" + errorCode + " recipients. " +
-         abortMessage + "\r\n";
+  return ":irc.42tokyo.jp 407 " + nick + " " + target + " :" + errorCode +
+         " recipients. " + abortMessage + "\r\n";
+}
+
+// 411
+inline std::string ERR_NORECIPIENT(const std::string& nick,
+                                   const std::string& command) {
+  return ":irc.42tokyo.jp 411 " + nick + " " + command +
+         " :No recipient given\r\n";
 }
 
 // 421
-inline std::string ERR_UNKNOWNCOMMAND(const std::string nick,
+inline std::string ERR_UNKNOWNCOMMAND(const std::string& nick,
                                       const std::string& command) {
   return ":irc.42tokyo.jp 421 " + nick + " " + command +
          " :Unknown command\r\n";
 }
 
 // 431
-inline std::string ERR_NONICKNAMEGIVEN() {
-  return ":irc.42tokyo.jp 431 :No nickname given\r\n";
+inline std::string ERR_NONICKNAMEGIVEN(const std::string& nick) {
+  return ":irc.42tokyo.jp 431 " + nick + " :No nickname given\r\n";
 }
 
 // 432
-inline std::string ERR_ERRONEUSNICKNAME(const std::string& nickname) {
-  return ":irc.42tokyo.jp 432 " + nickname + " :Erroneous nickname\r\n";
+inline std::string ERR_ERRONEUSNICKNAME(const std::string& nick,
+                                        const std::string& nickname) {
+  return ":irc.42tokyo.jp 432 " + nick + " " + nickname +
+         " :Erroneous nickname\r\n";
 }
 
 // 433
-inline std::string ERR_NICKNAMEINUSE(const std::string& nickname) {
-  return ":irc.42tokyo.jp 433 " + nickname + " :Nickname is already in use\r\n";
+inline std::string ERR_NICKNAMEINUSE(const std::string& nick,
+                                     const std::string& nickname) {
+  return ":irc.42tokyo.jp 433 " + nick + " " + nickname +
+         " :Nickname is already in use\r\n";
 }
 
 // 436
-inline std::string ERR_NICKCOLLISION(const std::string& nickname,
+inline std::string ERR_NICKCOLLISION(const std::string& nick,
+                                     const std::string& nickname,
                                      const std::string& user,
                                      const std::string& host) {
-  return ":irc.42tokyo.jp 436 " + nickname + " :Nickname collision KILL from " +
-         user + "@" + host + "\r\n";
+  return ":irc.42tokyo.jp 436 " + nick + " " + nickname +
+         " :Nickname collision KILL from " + user + "@" + host + "\r\n";
 }
 
 // 437
-inline std::string ERR_UNAVAILRESOURCE(const std::string& nickname,
+inline std::string ERR_UNAVAILRESOURCE(const std::string& nick,
+                                       const std::string& nickname,
                                        const std::string& channel) {
-  return ":irc.42tokyo.jp 437 " + nickname + "/" + channel +
+  return ":irc.42tokyo.jp 437 " + nick + " " + nickname + "/" + channel +
          " :Nick/channel is temporarily unavailable\r\n";
 }
 
+// 442
+inline std::string ERR_NOTONCHANNEL(const std::string& nick,
+                                    const std::string& channel) {
+  return ":irc.42tokyo.jp 442 " + nick + " " + channel +
+         " :You're not on that channel\r\n";
+}
+
 // 451
-inline std::string ERR_NOTREGISTERED() {
-  return ":irc.42tokyo.jp 451 :You have not registered\r\n";
+inline std::string ERR_NOTREGISTERED(const std::string& nick) {
+  return ":irc.42tokyo.jp 451 " + nick + " :You have not registered\r\n";
 }
 
 // 461
-inline std::string ERR_NEEDMOREPARAMS(const std::string& command) {
-  return ":irc.42tokyo.jp 461 " + command + " :Not enough parameters\r\n";
+inline std::string ERR_NEEDMOREPARAMS(const std::string& nick,
+                                      const std::string& command) {
+  return ":irc.42tokyo.jp 461 " + nick + " " + command +
+         " :Not enough parameters\r\n";
 }
 
 // 462
-inline std::string ERR_ALREADYREGISTRED() {
-  return ":irc.42tokyo.jp 462 :Unauthorized command (already registered)\r\n";
+inline std::string ERR_ALREADYREGISTRED(const std::string& nick) {
+  return ":irc.42tokyo.jp 462 " + nick +
+         " :Unauthorized command (already registered)\r\n";
 }
 
 // 464
-inline std::string ERR_PASSWDMISMATCH() {
-  return ":server 464 :Password incorrect\r\n";
+inline std::string ERR_PASSWDMISMATCH(const std::string& nick) {
+  return ":server 464 " + nick + " :Password incorrect\r\n";
 }
 
 // 471
-inline std::string ERR_CHANNELISFULL(const std::string& channel) {
-  return ":irc.42tokyo.jp 471 " + channel + " :Cannot join channel (+l)\r\n";
+inline std::string ERR_CHANNELISFULL(const std::string& nick,
+                                     const std::string& channel) {
+  return ":irc.42tokyo.jp 471 " + nick + " " + channel +
+         " :Cannot join channel (+l)\r\n";
 }
 
 // 472
-inline std::string ERR_UNKNOWNMODE(char mode, const std::string& channel) {
-  return ":irc.42tokyo.jp 472 " + std::string(1, mode) +
+inline std::string ERR_UNKNOWNMODE(const std::string& nick, char mode,
+                                   const std::string& channel) {
+  return ":irc.42tokyo.jp 472 " + nick + " " + std::string(1, mode) +
          " :is unknown mode char to me for " + channel + "\r\n";
 }
 
 // 473
-inline std::string ERR_INVITEONLYCHAN(const std::string& channel) {
-  return ":irc.42tokyo.jp 473 " + channel + " :Cannot join channel (+i)\r\n";
+inline std::string ERR_INVITEONLYCHAN(const std::string& nick,
+                                      const std::string& channel) {
+  return ":irc.42tokyo.jp 473 " + nick + " " + channel +
+         " :Cannot join channel (+i)\r\n";
 }
 
 // 474
-inline std::string ERR_BANNEDFROMCHAN(const std::string& channel) {
-  return ":irc.42tokyo.jp 474 " + channel + " :Cannot join channel (+b)\r\n";
+inline std::string ERR_BANNEDFROMCHAN(const std::string& nick,
+                                      const std::string& channel) {
+  return ":irc.42tokyo.jp 474 " + nick + " " + channel +
+         " :Cannot join channel (+b)\r\n";
 }
 
 // 475
-inline std::string ERR_BADCHANNELKEY(const std::string& channel) {
-  return ":irc.42tokyo.jp 475 " + channel + " :Cannot join channel (+k)\r\n";
+inline std::string ERR_BADCHANNELKEY(const std::string& nick,
+                                     const std::string& channel) {
+  return ":irc.42tokyo.jp 475 " + nick + " " + channel +
+         " :Cannot join channel (+k)\r\n";
 }
 
 // 476
-inline std::string ERR_BADCHANMASK(const std::string& channel) {
-  return ":irc.42tokyo.jp 476 " + channel + " :Bad Channel Mask\r\n";
+inline std::string ERR_BADCHANMASK(const std::string& nick,
+                                   const std::string& channel) {
+  return ":irc.42tokyo.jp 476 " + nick + " " + channel +
+         " :Bad Channel Mask\r\n";
 }
 
 // 481
-inline std::string ERR_NOPRIVILEGES() {
-  return ":irc.42tokyo.jp 481 :Permission Denied - You're not an IRC "
+inline std::string ERR_NOPRIVILEGES(const std::string& nick) {
+  return ":irc.42tokyo.jp 481 " + nick +
+         " :Permission Denied - You're not an IRC "
          "operator\r\n";
 }
 
 // 482
-inline std::string ERR_CHANOPRIVSNEEDED(const std::string& channel) {
-  return ":irc.42tokyo.jp 482 :" + channel +
+inline std::string ERR_CHANOPRIVSNEEDED(const std::string& nick,
+                                        const std::string& channel) {
+  return ":irc.42tokyo.jp 482 " + nick + " :" + channel +
          " :You're not channel operator\r\n";
 }
 
 // 484
-inline std::string ERR_RESTRICTED() {
-  return ":irc.42tokyo.jp 484 :Your connection is restricted!\r\n";
+inline std::string ERR_RESTRICTED(const std::string& nick) {
+  return ":irc.42tokyo.jp 484 " + nick + " :Your connection is restricted!\r\n";
 }
 
 // 491
-inline std::string ERR_NOOPERHOST() {
-  return ":irc.42tokyo.jp 491 :No O-lines for your host\r\n";
+inline std::string ERR_NOOPERHOST(const std::string& nick) {
+  return ":irc.42tokyo.jp 491 " + nick + " :No O-lines for your host\r\n";
 }
 
 }  // namespace numericReplies

--- a/ft_irc/src/Server.cpp
+++ b/ft_irc/src/Server.cpp
@@ -261,10 +261,14 @@ void Server::deleteAllChannels() {
 }
 
 void Server::killServer() {
-  std::string msg = irc::numericReplies::ERR_RESTRICTED();
-  sendAllClients(msg);
+  for (std::map<int, Client*>::iterator it = clients.begin();
+       it != clients.end(); ++it) {
+    std::string msg =
+        irc::numericReplies::ERR_RESTRICTED(it->second->getNickname());
+    it->second->sendMessage(msg);
+  }
 
-  sleep(5);  // 5秒待機
+  sleep(3);  // 3秒待機
 
   for (std::map<int, Client*>::iterator it = clients.begin();
        it != clients.end(); ++it) {

--- a/ft_irc/src/commands/JoinCommand.cpp
+++ b/ft_irc/src/commands/JoinCommand.cpp
@@ -36,13 +36,15 @@ static const std::vector<std::string> parsers(std::string params) {
  */
 void JoinCommand::execute(const commandS& cmd, Client& client, Server& server) {
   if (!client.isRegistered()) {
-    std::string msg = irc::numericReplies::ERR_NOTREGISTERED();
+    std::string msg =
+        irc::numericReplies::ERR_NOTREGISTERED(client.getNickname());
     client.sendMessage(msg);
     return;
   }
 
   if (cmd.args.size() < 1) {
-    std::string msg = irc::numericReplies::ERR_NEEDMOREPARAMS(cmd.name);
+    std::string msg =
+        irc::numericReplies::ERR_NEEDMOREPARAMS(client.getNickname(), cmd.name);
     client.sendMessage(msg);
     return;
   }
@@ -51,7 +53,8 @@ void JoinCommand::execute(const commandS& cmd, Client& client, Server& server) {
   std::vector<std::string> channels = parsers(cmd.args[0]);
   for (size_t i = 0; i < channels.size(); ++i) {
     if (!server.isValidChannelName(channels[i])) {
-      std::string msg = irc::numericReplies::ERR_BADCHANMASK(channels[i]);
+      std::string msg = irc::numericReplies::ERR_BADCHANMASK(
+          client.getNickname(), channels[i]);
       client.sendMessage(msg);
       return;
     }
@@ -62,7 +65,8 @@ void JoinCommand::execute(const commandS& cmd, Client& client, Server& server) {
     keys = parsers(cmd.args[1]);
     for (size_t i = 0; i < keys.size(); ++i) {
       if (!server.isValidChannelKey(keys[i])) {
-        std::string msg = irc::numericReplies::ERR_BADCHANNELKEY(channels[i]);
+        std::string msg = irc::numericReplies::ERR_BADCHANNELKEY(
+            client.getNickname(), keys[i]);
         client.sendMessage(msg);
         return;
       }
@@ -81,29 +85,34 @@ void JoinCommand::execute(const commandS& cmd, Client& client, Server& server) {
       // チャンネルに参加する
       Channel* channel = server.channels[channels[i]];  // チャンネルを取得
       if (channel->getClientCount() >= 50) {            // TODO
-        std::string msg = irc::numericReplies::ERR_CHANNELISFULL(channels[i]);
+        std::string msg = irc::numericReplies::ERR_CHANNELISFULL(
+            client.getNickname(), channels[i]);
         client.sendMessage(msg);
         return;
       }
       if (channel->isInviteOnly()) {
-        std::string msg = irc::numericReplies::ERR_INVITEONLYCHAN(channels[i]);
+        std::string msg = irc::numericReplies::ERR_INVITEONLYCHAN(
+            client.getNickname(), channels[i]);
         client.sendMessage(msg);
         return;
       }
       if (channel->hasClient(&client)) {
-        std::string msg = irc::numericReplies::ERR_BANNEDFROMCHAN(channels[i]);
+        std::string msg = irc::numericReplies::ERR_BANNEDFROMCHAN(
+            client.getNickname(), channels[i]);
         client.sendMessage(msg);
         return;
       }
       // チャンネルに参加する
       if (keys.size() > i) {
         if (keys[i] != channel->getKey()) {
-          std::string msg = irc::numericReplies::ERR_BADCHANNELKEY(channels[i]);
+          std::string msg = irc::numericReplies::ERR_BADCHANNELKEY(
+              client.getNickname(), channels[i]);
           client.sendMessage(msg);
           return;
         }
       } else if (channel->getKey() != "") {
-        std::string msg = irc::numericReplies::ERR_BADCHANNELKEY(channels[i]);
+        std::string msg = irc::numericReplies::ERR_BADCHANNELKEY(
+            client.getNickname(), channels[i]);
         client.sendMessage(msg);
         return;
       }

--- a/ft_irc/src/commands/JoinCommand.cpp
+++ b/ft_irc/src/commands/JoinCommand.cpp
@@ -113,8 +113,8 @@ void JoinCommand::execute(const commandS& cmd, Client& client, Server& server) {
                             client.getUsername() + "@" + client.getHostname() +
                             " JOIN " + channels[i] + "\r\n";
       channel->sendToAll(joinMsg);
-      std::string topicMsg =
-          irc::numericReplies::RPL_TOPIC(channels[i], channel->getTopic());
+      std::string topicMsg = irc::numericReplies::RPL_TOPIC(
+          client.getNickname(), channels[i], channel->getTopic());
       client.sendMessage(topicMsg);
     }
   }

--- a/ft_irc/src/commands/KickCommand.cpp
+++ b/ft_irc/src/commands/KickCommand.cpp
@@ -8,8 +8,9 @@
 #include "numericsReplies/400-499.hpp"
 
 void KickCommand::execute(const commandS& cmd, Client& client, Server& server) {
+  std::string nick = client.getNickname().empty() ? "*" : client.getNickname();
   if (!client.isRegistered()) {
-    std::string msg = irc::numericReplies::ERR_NOTREGISTERED();
+    std::string msg = irc::numericReplies::ERR_NOTREGISTERED(nick);
     client.sendMessage(msg);
     return;
   }

--- a/ft_irc/src/commands/ModeCommand.cpp
+++ b/ft_irc/src/commands/ModeCommand.cpp
@@ -42,15 +42,15 @@ void channelMode(const commandS& cmd, Channel& channel, Client& client,
   // TODO
 
   if (!channel.isOperator(client.getNickname())) {
-    std::string msg =
-        irc::numericReplies::ERR_CHANOPRIVSNEEDED(channel.getName());
+    std::string msg = irc::numericReplies::ERR_CHANOPRIVSNEEDED(
+        client.getNickname(), channel.getName());
     client.sendMessage(msg);
     return;
   }
 
   if (!isValidSign(cmd.args[1][0])) {
-    std::string msg =
-        irc::numericReplies::ERR_UNKNOWNMODE(cmd.args[1][0], channel.getName());
+    std::string msg = irc::numericReplies::ERR_UNKNOWNMODE(
+        client.getNickname(), cmd.args[1][0], channel.getName());
     client.sendMessage(msg);
     return;
   }
@@ -59,8 +59,8 @@ void channelMode(const commandS& cmd, Channel& channel, Client& client,
   for (std::string::const_iterator it = cmd.args[1].begin() + 1;
        it != cmd.args[1].end(); ++it) {
     if (!isValidMode(*it)) {
-      std::string msg =
-          irc::numericReplies::ERR_UNKNOWNMODE(*it, channel.getName());
+      std::string msg = irc::numericReplies::ERR_UNKNOWNMODE(
+          client.getNickname(), *it, channel.getName());
       client.sendMessage(msg);
       return;
     }
@@ -74,7 +74,8 @@ void channelMode(const commandS& cmd, Channel& channel, Client& client,
       channel.setTopicRestricted(sign);
     } else if (*it == 'k') {
       if (cmd.args.size() < 3) {
-        std::string msg = irc::numericReplies::ERR_NEEDMOREPARAMS(cmd.name);
+        std::string msg = irc::numericReplies::ERR_NEEDMOREPARAMS(
+            client.getNickname(), cmd.name);
         client.sendMessage(msg);
         return;
       }
@@ -82,8 +83,8 @@ void channelMode(const commandS& cmd, Channel& channel, Client& client,
         channel.setKey(cmd.args[2]);
       } else {
         if (channel.getKey() != cmd.args[2]) {
-          std::string msg =
-              irc::numericReplies::ERR_BADCHANNELKEY(channel.getName());
+          std::string msg = irc::numericReplies::ERR_BADCHANNELKEY(
+              client.getNickname(), channel.getName());
           client.sendMessage(msg);
           return;
         }
@@ -98,7 +99,8 @@ void channelMode(const commandS& cmd, Channel& channel, Client& client,
     } else if (*it == 'l') {
       if (sign) {
         if (cmd.args.size() < 3) {
-          std::string msg = irc::numericReplies::ERR_NEEDMOREPARAMS(cmd.name);
+          std::string msg = irc::numericReplies::ERR_NEEDMOREPARAMS(
+              client.getNickname(), cmd.name);
           client.sendMessage(msg);
           return;
         }
@@ -116,14 +118,16 @@ void channelMode(const commandS& cmd, Channel& channel, Client& client,
 }
 
 void ModeCommand::execute(const commandS& cmd, Client& client, Server& server) {
+  std::string nick = client.getNickname().empty() ? "*" : client.getNickname();
   if (!client.isRegistered()) {
-    std::string msg = irc::numericReplies::ERR_NOTREGISTERED();
+    std::string msg = irc::numericReplies::ERR_NOTREGISTERED(nick);
     client.sendMessage(msg);
     return;
   }
 
   if (cmd.args.size() < 2) {
-    std::string msg = irc::numericReplies::ERR_NEEDMOREPARAMS(cmd.name);
+    std::string msg =
+        irc::numericReplies::ERR_NEEDMOREPARAMS(client.getNickname(), cmd.name);
     client.sendMessage(msg);
     return;
   }
@@ -135,7 +139,8 @@ void ModeCommand::execute(const commandS& cmd, Client& client, Server& server) {
     Channel* channel = server.channels[channelName];
 
     if (!channel) {
-      std::string msg = irc::numericReplies::ERR_NOSUCHCHANNEL(channelName);
+      std::string msg = irc::numericReplies::ERR_NOSUCHCHANNEL(
+          client.getNickname(), channelName);
       client.sendMessage(msg);
       return;
     }

--- a/ft_irc/src/commands/ModeCommand.cpp
+++ b/ft_irc/src/commands/ModeCommand.cpp
@@ -108,7 +108,7 @@ void channelMode(const commandS& cmd, Channel& channel, Client& client,
       }
     }
     std::string msg = irc::numericReplies::RPL_CHANNELMODEIS(
-        channel.getName(), cmd.args[1], channel.getKey());
+        client.getNickname(), channel.getName(), cmd.args[1], cmd.args[2]);
   }
 
   std::string serverName = server.getServerName();

--- a/ft_irc/src/commands/NickCommand.cpp
+++ b/ft_irc/src/commands/NickCommand.cpp
@@ -15,27 +15,29 @@
  */
 void NickCommand::execute(const commandS& cmd, Client& client, Server& server) {
   // before PASS command
+  const std::string& nick =
+      client.getNickname().empty() ? "*" : client.getNickname();
   if (!client.isAuthenticated()) {
-    std::string msg = irc::numericReplies::ERR_NOTREGISTERED();
+    std::string msg = irc::numericReplies::ERR_NOTREGISTERED("*");
     client.sendMessage(msg);
     return;
   }
 
   if (cmd.args.empty()) {
-    std::string msg = irc::numericReplies::ERR_NONICKNAMEGIVEN();
+    std::string msg = irc::numericReplies::ERR_NONICKNAMEGIVEN(nick);
     client.sendMessage(msg);
     return;
   }
 
   std::string nickname = cmd.args[0];
   if (!client.isValidNickname(nickname)) {
-    std::string msg = irc::numericReplies::ERR_ERRONEUSNICKNAME(nickname);
+    std::string msg = irc::numericReplies::ERR_ERRONEUSNICKNAME(nick, nickname);
     client.sendMessage(msg);
     return;
   }
 
   if (server.isAlreadyUsedNickname(nickname)) {
-    std::string msg = irc::numericReplies::ERR_NICKNAMEINUSE(nickname);
+    std::string msg = irc::numericReplies::ERR_NICKNAMEINUSE(nick, nickname);
     client.sendMessage(msg);
     return;
   }

--- a/ft_irc/src/commands/OperCommand.cpp
+++ b/ft_irc/src/commands/OperCommand.cpp
@@ -14,8 +14,10 @@
  * RPL_YOUREOPER: オペレータ権限を取得した
  */
 void OperCommand::execute(const commandS& cmd, Client& client, Server& server) {
+  const std::string& nick =
+      client.getNickname().empty() ? "*" : client.getNickname();
   if (!client.isRegistered()) {
-    std::string msg = irc::numericReplies::ERR_NOTREGISTERED();
+    std::string msg = irc::numericReplies::ERR_NOTREGISTERED(nick);
     client.sendMessage(msg);
     return;
   }
@@ -27,25 +29,28 @@ void OperCommand::execute(const commandS& cmd, Client& client, Server& server) {
   }
 
   if (cmd.args.size() < 2) {
-    std::string msg = irc::numericReplies::ERR_NEEDMOREPARAMS(cmd.name);
+    std::string msg =
+        irc::numericReplies::ERR_NEEDMOREPARAMS(client.getNickname(), cmd.name);
     client.sendMessage(msg);
     return;
   }
 
   if (client.getHostname() != AUTHORIZED_HOSTS) {
-    std::string msg = irc::numericReplies::ERR_NOOPERHOST();
+    std::string msg = irc::numericReplies::ERR_NOOPERHOST(client.getNickname());
     client.sendMessage(msg);
     return;
   }
 
   if (cmd.args[0] != client.getUsername()) {
-    std::string msg = irc::numericReplies::ERR_PASSWDMISMATCH();
+    std::string msg =
+        irc::numericReplies::ERR_PASSWDMISMATCH(client.getNickname());
     client.sendMessage(msg);
     return;
   }
 
   if (cmd.args[1] != server.getServerPassword()) {
-    std::string msg = irc::numericReplies::ERR_PASSWDMISMATCH();
+    std::string msg =
+        irc::numericReplies::ERR_PASSWDMISMATCH(client.getNickname());
     client.sendMessage(msg);
     return;
   }

--- a/ft_irc/src/commands/OperCommand.cpp
+++ b/ft_irc/src/commands/OperCommand.cpp
@@ -21,7 +21,7 @@ void OperCommand::execute(const commandS& cmd, Client& client, Server& server) {
   }
 
   if (client.isOperator()) {
-    std::string msg = irc::numericReplies::RPL_YOUREOPER();
+    std::string msg = irc::numericReplies::RPL_YOUREOPER(client.getNickname());
     client.sendMessage(msg);
     return;
   }
@@ -51,6 +51,6 @@ void OperCommand::execute(const commandS& cmd, Client& client, Server& server) {
   }
 
   client.setOperator(true);
-  std::string msg = irc::numericReplies::RPL_YOUREOPER();
+  std::string msg = irc::numericReplies::RPL_YOUREOPER(client.getNickname());
   client.sendMessage(msg);
 }

--- a/ft_irc/src/commands/PartCommand.cpp
+++ b/ft_irc/src/commands/PartCommand.cpp
@@ -5,23 +5,26 @@
 #include "numericsReplies/400-499.hpp"
 
 void PartCommand::execute(const commandS& cmd, Client& client, Server& server) {
+  const std::string& nick =
+      client.getNickname().empty() ? "*" : client.getNickname();
   if (!client.isRegistered()) {
-    std::string msg = irc::numericReplies::ERR_NOTREGISTERED();
+    std::string msg = irc::numericReplies::ERR_NOTREGISTERED(nick);
     client.sendMessage(msg);
     return;
   }
 
   if (cmd.args.empty()) {
-    client.sendMessage("461 PART :Not enough parameters\r\n");
+    std::string msg =
+        irc::numericReplies::ERR_NEEDMOREPARAMS(client.getNickname(), cmd.name);
+    client.sendMessage(msg);
     return;
   }
 
   std::string channelName = cmd.args[0];
-
   // チャンネルが存在しない場合はエラー
   if (server.channels.find(channelName) == server.channels.end()) {
-    client.sendMessage(":server 403 " + client.getNickname() + " " +
-                       channelName + " :No such channel\r\n");
+    const std::string msg = irc::numericReplies::ERR_NOSUCHCHANNEL(
+        client.getNickname(), channelName);
     return;
   }
 
@@ -29,8 +32,8 @@ void PartCommand::execute(const commandS& cmd, Client& client, Server& server) {
 
   // チャンネルに参加していない場合はエラー
   if (!channel->hasClient(&client)) {
-    client.sendMessage(":server 442 " + client.getNickname() + " " +
-                       channelName + " :You're not on that channel\r\n");
+    const std::string msg = irc::numericReplies::ERR_NOTONCHANNEL(
+        client.getNickname(), channelName);
     return;
   }
 }

--- a/ft_irc/src/commands/PassCommand.cpp
+++ b/ft_irc/src/commands/PassCommand.cpp
@@ -6,14 +6,16 @@
 #include "numericsReplies/400-499.hpp"
 
 void PassCommand::execute(const commandS& cmd, Client& client, Server& server) {
+  const std::string& nick =
+      client.getNickname().empty() ? "*" : client.getNickname();
   if (cmd.args.empty()) {
-    std::string msg = irc::numericReplies::ERR_NEEDMOREPARAMS(cmd.name);
+    std::string msg = irc::numericReplies::ERR_NEEDMOREPARAMS(nick, cmd.name);
     client.sendMessage(msg);
     return;
   }
 
   if (client.isAuthenticated()) {
-    std::string msg = irc::numericReplies::ERR_ALREADYREGISTRED();
+    std::string msg = irc::numericReplies::ERR_ALREADYREGISTRED(nick);
     client.sendMessage(msg);
     return;
   }
@@ -22,7 +24,7 @@ void PassCommand::execute(const commandS& cmd, Client& client, Server& server) {
   if (cmd.args[0] == password) {
     client.setAuthenticated(true);
   } else {
-    std::string msg = irc::numericReplies::ERR_PASSWDMISMATCH();
+    std::string msg = irc::numericReplies::ERR_PASSWDMISMATCH(nick);
     client.sendMessage(msg);
   }
 }

--- a/ft_irc/src/commands/PingCommand.cpp
+++ b/ft_irc/src/commands/PingCommand.cpp
@@ -7,8 +7,10 @@
 #include "numericsReplies/400-499.hpp"
 
 void PingCommand::execute(const commandS& cmd, Client& client, Server& server) {
+  const std::string& nick =
+      client.getNickname().empty() ? "*" : client.getNickname();
   if (!client.isRegistered()) {
-    std::string msg = irc::numericReplies::ERR_NOTREGISTERED();
+    std::string msg = irc::numericReplies::ERR_NOTREGISTERED(nick);
     client.sendMessage(msg);
     return;
   }

--- a/ft_irc/src/commands/PrivmsgCommand.cpp
+++ b/ft_irc/src/commands/PrivmsgCommand.cpp
@@ -7,15 +7,18 @@
 
 void PrivmsgCommand::execute(const commandS& cmd, Client& client,
                              Server& server) {
+  const std::string& nick =
+      client.getNickname().empty() ? "*" : client.getNickname();
   if (!client.isRegistered()) {
-    std::string msg = irc::numericReplies::ERR_NOTREGISTERED();
+    std::string msg = irc::numericReplies::ERR_NOTREGISTERED(nick);
     client.sendMessage(msg);
     return;
   }
 
   if (cmd.args.size() < 2) {
-    client.sendMessage(":server 411 " + client.getNickname() +
-                       " :No recipient given\r\n");
+    std::string msg =
+        irc::numericReplies::ERR_NORECIPIENT(client.getNickname(), cmd.name);
+    client.sendMessage(msg);
     return;
   }
 
@@ -33,8 +36,9 @@ void PrivmsgCommand::execute(const commandS& cmd, Client& client,
         (*it)->sendMessage(privmsg);
       }
     } else {
-      client.sendMessage(":server 403 " + client.getNickname() + " " + target +
-                         " :No such channel\r\n");
+      std::string msg =
+          irc::numericReplies::ERR_NOSUCHCHANNEL(client.getNickname(), target);
+      client.sendMessage(msg);
     }
   }
   // ユーザーにメッセージを送信

--- a/ft_irc/src/commands/QuitCommand.cpp
+++ b/ft_irc/src/commands/QuitCommand.cpp
@@ -8,8 +8,10 @@
 #include "numericsReplies/400-499.hpp"
 
 void QuitCommand::execute(const commandS& cmd, Client& client, Server& server) {
+  const std::string& nick =
+      client.getNickname().empty() ? "*" : client.getNickname();
   if (!client.isRegistered()) {
-    std::string msg = irc::numericReplies::ERR_NOTREGISTERED();
+    std::string msg = irc::numericReplies::ERR_NOTREGISTERED(nick);
     client.sendMessage(msg);
     return;
   }

--- a/ft_irc/src/commands/SquitCommand.cpp
+++ b/ft_irc/src/commands/SquitCommand.cpp
@@ -9,26 +9,30 @@
 
 void SquitCommand::execute(const commandS& cmd, Client& client,
                            Server& server) {
+  const std::string& nick =
+      client.getNickname().empty() ? "*" : client.getNickname();
   if (!client.isRegistered()) {
-    std::string msg = irc::numericReplies::ERR_NOTREGISTERED();
+    std::string msg = irc::numericReplies::ERR_NOTREGISTERED(nick);
     client.sendMessage(msg);
     return;
   }
 
   if (!client.isOperator()) {
-    std::string msg = irc::numericReplies::ERR_NOPRIVILEGES();
+    std::string msg = irc::numericReplies::ERR_NOPRIVILEGES(nick);
     client.sendMessage(msg);
     return;
   }
 
   if (cmd.args.size() < 2) {
-    std::string msg = irc::numericReplies::ERR_NEEDMOREPARAMS(cmd.name);
+    std::string msg =
+        irc::numericReplies::ERR_NEEDMOREPARAMS(client.getNickname(), cmd.name);
     client.sendMessage(msg);
     return;
   }
 
   if (cmd.args[0] != server.getServerName()) {
-    std::string msg = irc::numericReplies::ERR_NOSUCHSERVER(cmd.args[0]);
+    std::string msg = irc::numericReplies::ERR_NOSUCHSERVER(
+        client.getNickname(), cmd.args[0]);
     client.sendMessage(msg);
     return;
   }

--- a/ft_irc/src/commands/TopicCommand.cpp
+++ b/ft_irc/src/commands/TopicCommand.cpp
@@ -7,8 +7,10 @@
 
 void TopicCommand::execute(const commandS& cmd, Client& client,
                            Server& server) {
+  const std::string& nick =
+      client.getNickname().empty() ? "*" : client.getNickname();
   if (!client.isRegistered()) {
-    std::string msg = irc::numericReplies::ERR_NOTREGISTERED();
+    std::string msg = irc::numericReplies::ERR_NOTREGISTERED(nick);
     client.sendMessage(msg);
     return;
   }

--- a/ft_irc/src/commands/UserCommand.cpp
+++ b/ft_irc/src/commands/UserCommand.cpp
@@ -15,38 +15,43 @@
  * * USER <user> <mode> <unused> <realname>
  */
 void UserCommand::execute(const commandS& cmd, Client& client, Server& server) {
+  const std::string& nick =
+      client.getNickname().empty() ? "*" : client.getNickname();
   if (!client.isAuthenticated()) {
-    std::string msg = irc::numericReplies::ERR_NOTREGISTERED();
+    std::string msg = irc::numericReplies::ERR_NOTREGISTERED(nick);
     client.sendMessage(msg);
     return;
   }
 
   if (client.isRegistered()) {
-    std::string msg = irc::numericReplies::ERR_ALREADYREGISTRED();
+    std::string msg = irc::numericReplies::ERR_ALREADYREGISTRED(nick);
     client.sendMessage(msg);
     return;
   }
 
   if (client.getNickname().empty()) {
-    std::string msg = irc ::numericReplies::ERR_NOTREGISTERED();
+    std::string msg = irc ::numericReplies::ERR_NOTREGISTERED(nick);
     client.sendMessage(msg);
     return;
   }
 
   if (cmd.args.size() < 4) {
-    std::string msg = irc::numericReplies::ERR_NEEDMOREPARAMS(cmd.name);
+    std::string msg =
+        irc::numericReplies::ERR_NEEDMOREPARAMS(client.getNickname(), cmd.name);
     client.sendMessage(msg);
     return;
   }
 
   if (!client.isValidUsername(cmd.args[0])) {
-    std::string msg = irc::numericReplies::ERR_ERRONEUSNICKNAME(cmd.args[0]);
+    std::string msg = irc::numericReplies::ERR_ERRONEUSNICKNAME(
+        client.getNickname(), cmd.args[0]);
     client.sendMessage(msg);
     return;
   }
 
   if (!client.isValidRealname(cmd.args[3])) {
-    std::string msg = irc::numericReplies::ERR_ERRONEUSNICKNAME(cmd.args[3]);
+    std::string msg = irc::numericReplies::ERR_ERRONEUSNICKNAME(
+        client.getNickname(), cmd.args[3]);
     client.sendMessage(msg);
     return;
   }


### PR DESCRIPTION
# 概要

## 変更点

- `NumericsReplies` にターゲットを追加した。詳細は [RFC2818](https://datatracker.ietf.org/doc/html/rfc2812#section-2.4) に記載されている。
- 呼び出し元を全て変更した。

## 影響範囲
全てのコマンド。全範囲に及ぶ。

## テスト

- irssiからログインできることは確認している。また、join も使える。