### PR TITLE
nc コマンドと ^D 使えるようになったよ

### DIFF
--- a/ft_irc/src/Server.cpp
+++ b/ft_irc/src/Server.cpp
@@ -188,7 +188,14 @@ void Server::_processClientBuffer(Client* client) {
       pos = lfPos;
       erasePos = pos + 1;
     } else {
-      break;  // No more delimiters found
+      if (!buf.empty()) {
+        commandS cmd = _parser.parseCommand(buf);
+        if (!cmd.name.empty()) {
+          _commandDispatch(cmd, *client);
+        }
+      }
+      buf.clear();  // Clear the buffer if no complete command is found
+      break;        // No more delimiters found
     }
 
     std::string line = buf.substr(0, pos);

--- a/ft_irc/src/Server.cpp
+++ b/ft_irc/src/Server.cpp
@@ -173,6 +173,7 @@ void Server::_handleClientActivity(int clientFd) {
 
 void Server::_processClientBuffer(Client* client) {
   std::string& buf = client->getReadBuffer();
+  int clientFd = client->getFd();
 
   while (true) {
     size_t crlfPos = buf.find("\r\n");

--- a/ft_irc/src/Server.cpp
+++ b/ft_irc/src/Server.cpp
@@ -174,10 +174,19 @@ void Server::_handleClientActivity(int clientFd) {
 void Server::_processClientBuffer(Client* client) {
   std::string& buf = client->getReadBuffer();
   size_t pos;
+  size_t erasePos;
 
-  while ((pos = buf.find("\r\n")) != std::string::npos) {
+  while (buf.find("\n") != std::string::npos) {
+    if (buf.find("\r\n") != std::string::npos) {
+      pos = buf.find("\r\n");
+      erasePos = pos + 2;
+    } else {
+      pos = buf.find("\n");
+      erasePos = pos + 1;
+    }
+
     std::string line = buf.substr(0, pos);
-    buf.erase(0, pos + 2);  // "\r\n"を削除
+    buf.erase(0, erasePos);
     if (line.empty())
       continue;
     commandS cmd = _parser.parseCommand(line);
@@ -230,7 +239,7 @@ void Server::removeClientFromAllChannels(Client& client) {
         std::map<std::string, Channel*>::iterator tmp = it++;
         channels.erase(tmp);
         continue;
-      } 
+      }
     }
     it++;
   }

--- a/ft_irc/src/Server.cpp
+++ b/ft_irc/src/Server.cpp
@@ -173,16 +173,22 @@ void Server::_handleClientActivity(int clientFd) {
 
 void Server::_processClientBuffer(Client* client) {
   std::string& buf = client->getReadBuffer();
-  size_t pos;
-  size_t erasePos;
 
-  while (buf.find("\n") != std::string::npos) {
-    if (buf.find("\r\n") != std::string::npos) {
-      pos = buf.find("\r\n");
+  while (true) {
+    size_t crlfPos = buf.find("\r\n");
+    size_t lfPos = buf.find("\n");
+    size_t pos;
+    size_t erasePos;
+
+    if (crlfPos != std::string::npos &&
+        (lfPos == std::string::npos || crlfPos < lfPos)) {
+      pos = crlfPos;
       erasePos = pos + 2;
-    } else {
-      pos = buf.find("\n");
+    } else if (lfPos != std::string::npos) {
+      pos = lfPos;
       erasePos = pos + 1;
+    } else {
+      break;  // No more delimiters found
     }
 
     std::string line = buf.substr(0, pos);


### PR DESCRIPTION
# 概要

`nc` コマンドでも接続できるように修正しました
さらに `^D` も使用できるようになりました。

## 変更点

- `_processClientBuffer()` においてもともとは `find("\r\n")` で検索していたが、これを `find("\n")` に変更した。その後 `if` 分岐で `\r` を処理している
- `^D` が送信されたときもきちんと処理できるようにした。
    > `Use ctrl+D to send the command in several parts: ’com’, then ’man’, then ’d\n’.` 
    `recv()` 関数は `^D` が入力されるとその時点までのコマンドを受け取ることに注意

## 影響範囲

- `irssi` から接続する分には影響なし

## テスト

- `irssi` と同様に `nc` でも接続できるか確認

## 関連Issue

なし
