### PR TITLE
irssi で Password をミスしたときの無限ループを修正

### DIFF
--- a/ft_irc/include/Client.hpp
+++ b/ft_irc/include/Client.hpp
@@ -4,12 +4,12 @@
 class Client {
  private:
   // 接続情報・認証情報
-
   int _fd;
   bool _authenticated;  // PASS
   bool _registered;     // PASS -> NICK -> USER
   std::string _readBuffer;
   std::string _hostname;
+  int _failPassCount;  // PASSの失敗回数
 
   // ユーザ情報
   std::string _nickname;
@@ -42,6 +42,8 @@ class Client {
   const std::string& getNickname() const;
   const std::string& getUsername() const;
   const std::string& getRealname() const;
+  const int& getFailPassCount() const;
+  void incrementFailPassCount();
   void setNickname(const std::string& nickname);
   void setUsername(const std::string& username);
   void setRealname(const std::string& realname);

--- a/ft_irc/include/Server.hpp
+++ b/ft_irc/include/Server.hpp
@@ -21,6 +21,7 @@ class ICommand;
 #define ENY_PROTOCOL 0
 #define BUFFER_SIZE 512
 #define NON_OPTIONAL 0
+#define MAX_TRY 3
 
 class Server {
  private:

--- a/ft_irc/include/Server.hpp
+++ b/ft_irc/include/Server.hpp
@@ -58,6 +58,7 @@ class Server {
   std::string getServerPassword() const;
 
   // Client Utilities
+  bool isClient(int clientFd) const;
   bool isAlreadyUsedNickname(const std::string& nickname) const;
   Client* getClientByNickname(const std::string& nickname) const;
   void sendAllClients(const std::string& message) const;

--- a/ft_irc/src/Client.cpp
+++ b/ft_irc/src/Client.cpp
@@ -20,7 +20,11 @@ std::string Client::_getClientHostname() const {
 }
 
 Client::Client(int fd)
-    : _fd(fd), _authenticated(false), _registered(false), _isOperator(false) {
+    : _fd(fd),
+      _authenticated(false),
+      _registered(false),
+      _failPassCount(0),
+      _isOperator(false) {
   _hostname = _getClientHostname();
 }
 
@@ -126,6 +130,14 @@ const std::string& Client::getUsername() const {
 
 const std::string& Client::getRealname() const {
   return _realname;
+}
+
+const int& Client::getFailPassCount() const {
+  return _failPassCount;
+}
+
+void Client::incrementFailPassCount() {
+  _failPassCount++;
 }
 
 void Client::setNickname(const std::string& nickname) {

--- a/ft_irc/src/Server.cpp
+++ b/ft_irc/src/Server.cpp
@@ -174,6 +174,7 @@ void Server::_handleClientActivity(int clientFd) {
 void Server::_processClientBuffer(Client* client) {
   std::string& buf = client->getReadBuffer();
   size_t pos;
+  int clientFd = client->getFd();
 
   while ((pos = buf.find("\r\n")) != std::string::npos) {
     std::string line = buf.substr(0, pos);
@@ -184,6 +185,9 @@ void Server::_processClientBuffer(Client* client) {
     if (cmd.name.empty())
       continue;
     _commandDispatch(cmd, *client);
+    if (!isClient(clientFd)) {
+      return;
+    }
   }
 }
 
@@ -204,6 +208,10 @@ void Server::_commandDispatch(const commandS& cmd, Client& client) {
 // ------------------------------
 // Client Utilities / Channel Utilities
 // ------------------------------
+
+bool Server::isClient(int clientFd) const {
+  return clients.find(clientFd) != clients.end();
+}
 
 void Server::removeClient(int clientFd) {
   std::cout << GREEN "Client disconnected: " << clientFd << RESET << std::endl;
@@ -230,7 +238,7 @@ void Server::removeClientFromAllChannels(Client& client) {
         std::map<std::string, Channel*>::iterator tmp = it++;
         channels.erase(tmp);
         continue;
-      } 
+      }
     }
     it++;
   }

--- a/ft_irc/src/commands/PassCommand.cpp
+++ b/ft_irc/src/commands/PassCommand.cpp
@@ -24,9 +24,8 @@ void PassCommand::execute(const commandS& cmd, Client& client, Server& server) {
   if (cmd.args[0] == password) {
     client.setAuthenticated(true);
   } else {
-    static size_t count = 0;
-    count++;
-    if (count >= 3) {
+    client.incrementFailPassCount();
+    if (client.getFailPassCount() >= MAX_TRY) {
       std::string msg = irc::numericReplies::ERR_RESTRICTED(nick);
       client.sendMessage(msg);
       server.removeClient(client.getFd());

--- a/ft_irc/src/commands/PassCommand.cpp
+++ b/ft_irc/src/commands/PassCommand.cpp
@@ -24,6 +24,14 @@ void PassCommand::execute(const commandS& cmd, Client& client, Server& server) {
   if (cmd.args[0] == password) {
     client.setAuthenticated(true);
   } else {
+    static size_t count = 0;
+    count++;
+    if (count >= 3) {
+      std::string msg = irc::numericReplies::ERR_RESTRICTED(nick);
+      client.sendMessage(msg);
+      server.removeClient(client.getFd());
+      return;
+    }
     std::string msg = irc::numericReplies::ERR_PASSWDMISMATCH(nick);
     client.sendMessage(msg);
   }


### PR DESCRIPTION
# 概要

`irssi` を使用したときに password を誤ると、無限ループに陥ってしまうバグを修正した

## 変更点

- `isClient(int clientFd) const` というメソッドを Server に追加
- `Pass` コマンド内で3回ミスしたらクライアントを削除（強制退会）させるようにした

## 影響範囲

特にない。

## テスト

このセクションでは、このPRに関連するテストケースやテスト方法を記載してください。

- テストケース1
- テストケース2
- テストケース3

## 関連Issue

このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。

- close #xxx
